### PR TITLE
Remove Board route nesting

### DIFF
--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -22,16 +22,11 @@ export const routesConfig: RouteObject[] = [
           },
           {
             path: 'boards',
-            children: [
-              {
-                index: true,
-                element: <Boards />,
-              },
-              {
-                path: 'board/:boardId',
-                element: <Board />,
-              },
-            ],
+            element: <Boards />,
+          },
+          {
+            path: 'board/:boardId',
+            element: <Board />,
           },
           {
             path: 'signup',
@@ -58,7 +53,7 @@ export const routesConfig: RouteObject[] = [
 export const routes = {
   MAIN: '/',
   BOARDS: '/boards',
-  BOARD: '/boards/board/',
+  BOARD: '/board',
   SIGN_UP: '/signup',
   SIGN_IN: '/signin',
 };


### PR DESCRIPTION
The purpose to make a single Board page to be independant of Boards (because there is no other entities or paths, available from `/boards/` path) and available from root path.