### PR TITLE
Boards owner names and delete confirmation

### DIFF
--- a/src/config/data.ts
+++ b/src/config/data.ts
@@ -294,6 +294,7 @@ const toastMessages = {
 const confirmationModalText = {
   signOut: 'Confirm your sign out',
   deleteProfile: 'Do you really want to delete your profile?',
+  deleteBoard: 'Delete the board?',
 };
 
 export {

--- a/src/services/boards/types.ts
+++ b/src/services/boards/types.ts
@@ -8,4 +8,8 @@ interface BoardsResponse extends Board {
   _id: string;
 }
 
-export type { Board, BoardsResponse };
+interface BoardFilled extends BoardsResponse {
+  ownerName: string;
+}
+
+export type { Board, BoardsResponse, BoardFilled };


### PR DESCRIPTION
- Changed boards page to only load boards, which have current user as owner or user (in users array) - `getBoardsByUserId` (previous implementation was loading all the boards for all users)
- Fixed owner to contain user id instead of user login (because server expects id) - to let the above mentioned feature work.
- Added ownerName field to board to contain a name of owner user (additional query is made)

- Added confirmation modal for deleting a board

![image](https://user-images.githubusercontent.com/83244224/205680038-3e12613b-7f9b-4a9b-9321-72bcbc3129d1.png)
